### PR TITLE
Update MoPubUnityPlugin.java

### DIFF
--- a/mopub-android-sdk-unity/src/main/java/com/mopub/unity/MoPubUnityPlugin.java
+++ b/mopub-android-sdk-unity/src/main/java/com/mopub/unity/MoPubUnityPlugin.java
@@ -580,7 +580,7 @@ public class MoPubUnityPlugin {
                     if (fieldNode.isValueNode()) {
                         options.put(key, ((JrsValue)fieldNode).asText());
                     } else {
-                        options.put(key, node.toString());
+                        options.put(key, fieldNode.toString());
                     }
                 }
                 allOptions.put(adapterConfigClass, options);

--- a/mopub-android-sdk-unity/src/main/java/com/mopub/unity/MoPubUnityPlugin.java
+++ b/mopub-android-sdk-unity/src/main/java/com/mopub/unity/MoPubUnityPlugin.java
@@ -575,7 +575,13 @@ public class MoPubUnityPlugin {
                 final Map<String, String> options = new HashMap<>();
                 for (Iterator<String> keys2 = optionsData.fieldNames(); keys2.hasNext(); ) {
                     String key = keys2.next();
-                    options.put(key, optionsData.get(key).toString());
+                    
+                    TreeNode fieldNode = optionsData.get(key);
+                    if (fieldNode.isValueNode()) {
+                        options.put(key, ((JrsValue)fieldNode).asText());
+                    } else {
+                        options.put(key, node.toString());
+                    }
                 }
                 allOptions.put(adapterConfigClass, options);
             } else {


### PR DESCRIPTION
JRSValue nodes values should be retrieved using asText. They do not override toString.