### PR TITLE
Remove double-semicolons to prevent code-unreachable errors

### DIFF
--- a/unity-sample-app/Assets/MoPub/Scripts/Internal/MoPubiOS.cs
+++ b/unity-sample-app/Assets/MoPub/Scripts/Internal/MoPubiOS.cs
@@ -173,7 +173,7 @@ internal class MoPubiOS : MoPubPlatformApi
     internal override string CurrentConsentPrivacyPolicyUrl
     {
         get {
-            return _moPubCurrentConsentPrivacyPolicyUrl(MoPub.ConsentLanguageCode);;
+            return _moPubCurrentConsentPrivacyPolicyUrl(MoPub.ConsentLanguageCode);
         }
         set { }
     }
@@ -182,7 +182,7 @@ internal class MoPubiOS : MoPubPlatformApi
     internal override string CurrentVendorListUrl
     {
         get {
-            return _moPubCurrentConsentVendorListUrl(MoPub.ConsentLanguageCode);;
+            return _moPubCurrentConsentVendorListUrl(MoPub.ConsentLanguageCode);
         }
         set { }
     }


### PR DESCRIPTION
These double-semicolons cause an "unreachable code" error in JetBrains Rider IDE.

This is probably not the right repository to fix this, but it's the only place I could find a copy of MoPubiOS.cs.  